### PR TITLE
feat: Add modular PHP Telegram bot for shared hosting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# ---------------------------------------------------------------
+# ENVIRONMENT
+# ---------------------------------------------------------------
+#
+# CodeIgniter environment. Can be:
+#   development
+#   testing
+#   production
+#
+CI_ENV=development
+
+
+# ---------------------------------------------------------------
+# TELEGRAM BOT
+# ---------------------------------------------------------------
+#
+# Your Telegram Bot token from BotFather.
+#
+TELEGRAM_BOT_TOKEN=

--- a/bot/ApiClient.php
+++ b/bot/ApiClient.php
@@ -1,0 +1,46 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+/**
+ * Class ApiClient
+ * Menangani semua komunikasi dengan Telegram Bot API.
+ */
+class ApiClient
+{
+    protected string $apiUrl;
+    protected Client $httpClient;
+
+    /**
+     * ApiClient constructor.
+     * @param string $token Token bot dari Telegram.
+     */
+    public function __construct(string $token)
+    {
+        $this->apiUrl = 'https://api.telegram.org/bot' . $token;
+        $this->httpClient = new Client(['base_uri' => $this->apiUrl]);
+    }
+
+    /**
+     * Mengirim pesan teks ke chat ID tertentu.
+     *
+     * @param int $chatId ID chat tujuan.
+     * @param string $text Teks pesan yang akan dikirim.
+     */
+    public function sendMessage(int $chatId, string $text): void
+    {
+        try {
+            $this->httpClient->post('sendMessage', [
+                'json' => [
+                    'chat_id' => $chatId,
+                    'text' => $text,
+                ]
+            ]);
+        } catch (GuzzleException $e) {
+            // Dalam aplikasi nyata, ini harus dicatat (logged).
+            // Untuk saat ini, kita abaikan sesuai instruksi.
+            error_log('Guzzle Error: ' . $e->getMessage());
+        }
+    }
+}

--- a/bot/BotHandler.php
+++ b/bot/BotHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Class BotHandler
+ * Memproses logika bisnis dari bot.
+ */
+class BotHandler
+{
+    protected ApiClient $api;
+
+    /**
+     * BotHandler constructor.
+     * @param ApiClient $api Klien API untuk mengirim balasan.
+     */
+    public function __construct(ApiClient $api)
+    {
+        $this->api = $api;
+    }
+
+    /**
+     * Menangani pembaruan mentah dari webhook.
+     * @param string $rawUpdate String JSON dari pembaruan Telegram.
+     */
+    public function handle(string $rawUpdate): void
+    {
+        $update = json_decode($rawUpdate, true);
+
+        if (!$update) {
+            // Abaikan jika data tidak valid
+            return;
+        }
+
+        if (isset($update['message'])) {
+            $message = $update['message'];
+            $chatId = $message['chat']['id'];
+            $text = $message['text'] ?? ''; // Gunakan null coalescing untuk menghindari error jika tidak ada teks
+
+            if ($text === '/start') {
+                $responseText = 'Halo! Selamat datang di bot modular PHP. Proyek ini siap untuk diunggah ke shared hosting.';
+                $this->api->sendMessage($chatId, $responseText);
+            } else {
+                // Untuk semua pesan lain, bot akan membalasnya (echo)
+                $responseText = 'Anda mengirim: ' . $text;
+                $this->api->sendMessage($chatId, $responseText);
+            }
+        }
+    }
+}

--- a/bot/index.php
+++ b/bot/index.php
@@ -1,0 +1,49 @@
+<?php
+
+// Atur zona waktu default untuk menghindari potensi error tanggal/waktu.
+date_default_timezone_set('Asia/Jakarta');
+
+// Aktifkan logging error ke file, penting untuk debugging di shared hosting.
+ini_set('log_errors', 1);
+ini_set('error_log', __DIR__ . '/error.log');
+ini_set('display_errors', 0); // Jangan tampilkan error ke pengguna
+
+// Muat autoloader Composer dari direktori root.
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// Muat file-file bot yang modular
+require_once __DIR__ . '/ApiClient.php';
+require_once __DIR__ . '/BotHandler.php';
+
+try {
+    // Muat variabel lingkungan dari file .env di direktori root
+    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
+    $dotenv->load();
+
+    // Ambil token bot dari environment variable
+    $botToken = $_ENV['TELEGRAM_BOT_TOKEN'] ?? null;
+    if (empty($botToken)) {
+        throw new Exception('TELEGRAM_BOT_TOKEN tidak diatur di file .env.');
+    }
+
+    // Inisialisasi komponen-komponen bot
+    $apiClient = new ApiClient($botToken);
+    $botHandler = new BotHandler($apiClient);
+
+    // Ambil pembaruan mentah dari input stream (data yang dikirim Telegram)
+    $update = file_get_contents('php://input');
+
+    // Pastikan ada pembaruan sebelum diproses
+    if ($update) {
+        $botHandler->handle($update);
+    }
+
+} catch (Exception $e) {
+    // Jika terjadi error, catat pesannya ke file log.
+    error_log('Error: ' . $e->getMessage());
+}
+
+// Selalu kembalikan respon HTTP 200 OK ke Telegram.
+// Ini memberitahu Telegram bahwa webhook telah menerima pembaruan dengan sukses.
+// Jika tidak, Telegram akan mencoba mengirim pembaruan yang sama berulang kali.
+http_response_code(200);


### PR DESCRIPTION
Creates a new standalone, modular Telegram bot in the `bot/` directory.

The bot is designed to be deployed on a shared hosting environment by using a webhook (`bot/index.php`) as the entry point.

Key features:
- Modular structure: Separates API communication (`ApiClient.php`), business logic (`BotHandler.php`), and the webhook entry point (`index.php`).
- .env based configuration: Uses the existing `.env` file in the project root for the bot token.
- Uses existing dependencies: Leverages the root `vendor/` directory without needing a separate `composer install`.
- Shared hosting ready: Includes error logging and expects to be called by the Telegram webhook.