### PR TITLE
fix: Add migrate method to Welcome controller

### DIFF
--- a/application/controllers/Welcome.php
+++ b/application/controllers/Welcome.php
@@ -22,4 +22,20 @@ class Welcome extends CI_Controller {
 	{
 		$this->load->view('welcome_message');
 	}
+
+	public function migrate()
+	{
+		$this->load->library('migration');
+
+		if ($this->migration->current() === FALSE)
+		{
+			show_error($this->migration->error_string());
+		}
+		else
+		{
+			// Migrations ran successfully, redirect to dashboard
+			$this->load->helper('url');
+			redirect('/dashboard');
+		}
+	}
 }


### PR DESCRIPTION
The migrate URL was returning a 404 error because the 'migrate' method was missing from the Welcome controller.

This commit adds the 'migrate' method to the Welcome controller. This method loads the CodeIgniter migration library and runs the database migrations. After a successful migration, it redirects you to the dashboard.