### PR TITLE
feat: Add migrate controller to run database migrations

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -56,3 +56,4 @@ $route['translate_uri_dashes'] = FALSE;
 // Rute kustom untuk dasbor dan pengaturan
 $route['dashboard'] = 'dashboard';
 $route['settings'] = 'settings';
+$route['migrate'] = 'migrate';

--- a/application/controllers/Migrate.php
+++ b/application/controllers/Migrate.php
@@ -1,0 +1,19 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migrate extends CI_Controller {
+
+    public function index()
+    {
+        $this->load->library('migration');
+
+        if ($this->migration->latest() === FALSE)
+        {
+            show_error($this->migration->error_string());
+        }
+        else
+        {
+            echo "Migrations ran successfully!";
+        }
+    }
+}


### PR DESCRIPTION
Adds a new `Migrate` controller to handle database migrations. This fixes the 404 error when clicking the "Jalankan Migrasi Database" button.

The controller can be accessed at the `/migrate` route.