### PR TITLE
Fix: Load form helper in Settings controller

### DIFF
--- a/application/controllers/Settings.php
+++ b/application/controllers/Settings.php
@@ -8,6 +8,7 @@ class Settings extends CI_Controller {
         parent::__construct();
         $this->load->model('Settings_model');
         $this->load->helper('url');
+        $this->load->helper('form');
         $this->load->library('session'); // Untuk menampilkan pesan feedback
     }
 


### PR DESCRIPTION
The `settings_view.php` view uses the `form_open()` function, but the corresponding `Settings` controller was not loading the `form` helper. This resulted in a fatal error, 'Call to undefined function form_open()'.

This commit adds the line to load the `form` helper in the `__construct()` method of the `Settings.php` controller, resolving the error.