### PR TITLE
Memperbaiki kesalahan fatal yang disebabkan oleh jalur file yang sala…

### DIFF
--- a/application/controllers/Settings.php
+++ b/application/controllers/Settings.php
@@ -11,7 +11,7 @@ class Settings extends CI_Controller {
         $this->load->helper('url');
         $this->load->helper('form');
         $this->load->library('session');
-        require_once APPPATH . 'bot/ApiClient.php'; // Include the ApiClient
+        require_once dirname(APPPATH) . '/bot/ApiClient.php'; // Correct path to ApiClient
     }
 
     public function index()


### PR DESCRIPTION
…h saat menyertakan `ApiClient.php` di controller `Settings.php`.

Jalur `require_once` sebelumnya menggunakan `APPPATH`, yang menunjuk ke direktori `application`. Ini mengakibatkan kesalahan "File not found" karena `ApiClient.php` terletak di direktori `bot/` di root proyek.

Jalur telah diperbaiki untuk menggunakan `dirname(APPPATH)` untuk menunjuk dengan benar ke direktori root proyek, memastikan file dimuat dengan benar.