### PR TITLE
Memperbaiki kesalahan "404 Not Found" pada URL webhook. Kesalahan ini…

### DIFF
--- a/application/controllers/Settings.php
+++ b/application/controllers/Settings.php
@@ -57,7 +57,13 @@ class Settings extends CI_Controller {
             return;
         }
 
-        $webhookUrl = site_url('bot/index.php', 'https');
+        // Gunakan base_url untuk mendapatkan path yang benar tanpa index.php tambahan
+        $webhookUrl = base_url('bot/index.php');
+
+        // Pastikan URL menggunakan HTTPS
+        if (strpos($webhookUrl, 'http://') === 0) {
+            $webhookUrl = 'https' . substr($webhookUrl, 4);
+        }
 
         try {
             $client = new \GuzzleHttp\Client();

--- a/application/views/settings_view.php
+++ b/application/views/settings_view.php
@@ -55,7 +55,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
         <h2>Webhook</h2>
         <p>Webhook adalah mekanisme di mana Telegram akan mengirim pembaruan (seperti pesan baru) ke server Anda.</p>
-        <p>URL Webhook untuk bot Anda adalah: <code><?php echo site_url('bot/index.php', 'https'); ?></code></p>
+        <p>URL Webhook untuk bot Anda adalah: <code><?php echo base_url('bot/index.php'); ?></code></p>
         <p>Klik tombol di bawah ini untuk mengatur URL ini secara otomatis di server Telegram. Pastikan token bot sudah disimpan dengan benar.</p>
         <a href="<?php echo site_url('settings/set_webhook'); ?>" class="btn btn-primary">Set Webhook</a>
 


### PR DESCRIPTION
… disebabkan oleh pembuatan URL yang salah, yang menambahkan `index.php` tambahan ke path.

Perubahan ini adalah:
- Mengganti `site_url()` dengan `base_url()` di `application/controllers/Settings.php` dan `application/views/settings_view.php` untuk menghasilkan URL webhook yang benar.
- Menambahkan logika di controller untuk memastikan URL yang dihasilkan menggunakan protokol `https` sebelum mengirimkannya ke API Telegram.

Ini memastikan bahwa Telegram dapat berhasil mencapai titik akhir bot.