### PR TITLE
Memperbaiki "500 Internal Server Error" pada titik akhir webhook (`bo…

### DIFF
--- a/bot/index.php
+++ b/bot/index.php
@@ -7,6 +7,9 @@ define('ENVIRONMENT', $_ENV['CI_ENV'] ?? 'production');
 // Ubah direktori kerja ke direktori root proyek
 chdir(__DIR__ . '/..');
 
+// Muat autoloader Composer
+require_once 'vendor/autoload.php';
+
 // Muat bootstrap CodeIgniter
 require_once BASEPATH . 'core/CodeIgniter.php';
 


### PR DESCRIPTION
…t/index.php`).

Kesalahan ini disebabkan oleh kegagalan skrip untuk menyertakan file `vendor/autoload.php` Composer. Hal ini mengakibatkan kesalahan fatal karena kelas yang dikelola oleh Composer, seperti GuzzleHttp\Client, tidak tersedia.

Dengan menambahkan `require_once 'vendor/autoload.php'`, saya memastikan semua dependensi yang diperlukan dimuat, menyelesaikan kesalahan fatal.