### PR TITLE
Tentu, saya telah mengubah metode HTTP dari GET ke POST untuk panggil…

### DIFF
--- a/bot/ApiClient.php
+++ b/bot/ApiClient.php
@@ -61,7 +61,7 @@ class ApiClient
     public function getWebhookInfo(): ?array
     {
         try {
-            $response = $this->httpClient->get('getWebhookInfo');
+            $response = $this->httpClient->post('getWebhookInfo'); // Ubah ke POST
             $body = json_decode((string) $response->getBody(), true);
 
             if ($response->getStatusCode() == 200 && ($body['ok'] ?? false)) {
@@ -85,7 +85,7 @@ class ApiClient
     public function deleteWebhook(): ?array
     {
         try {
-            $response = $this->httpClient->get('deleteWebhook');
+            $response = $this->httpClient->post('deleteWebhook'); // Ubah ke POST
             $body = json_decode((string) $response->getBody(), true);
 
             if ($response->getStatusCode() == 200 && ($body['ok'] ?? false)) {


### PR DESCRIPTION
…an API `getWebhookInfo` dan `deleteWebhook` di `ApiClient.php`.

Perubahan ini saya lakukan untuk mengatasi kesalahan "Gagal menghapus webhook" dan kesalahan serupa, yang mungkin disebabkan oleh lingkungan hosting Anda yang membatasi permintaan GET keluar ke API eksternal. API Bot Telegram mendukung POST untuk semua metode, jadi perubahan ini dapat melewati batasan tersebut.