### PR TITLE
Saya akan mengaktifkan pelaporan kesalahan PHP di bagian atas skrip `…

### DIFF
--- a/bot/index.php
+++ b/bot/index.php
@@ -1,4 +1,7 @@
 <?php
+// Aktifkan pelaporan error untuk debugging
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
 
 // Definisikan path absolut yang kokoh untuk menghindari masalah lingkungan
 $root_path = realpath(__DIR__ . '/..');


### PR DESCRIPTION
…bot/index.php`.

Ini adalah langkah diagnostik untuk mengidentifikasi akar penyebab "500 Internal Server Error" yang terus-menerus Anda alami. Dengan memaksa `display_errors` dan `error_reporting` aktif, setiap kesalahan fatal yang sebelumnya disembunyikan oleh pengaturan lingkungan produksi sekarang akan terlihat.