### PR TITLE
Memperbaiki kesalahan fatal: "Konstanta tidak terdefinisi 'VIEWPATH'".

### DIFF
--- a/bot/index.php
+++ b/bot/index.php
@@ -1,7 +1,4 @@
 <?php
-// Aktifkan pelaporan error untuk debugging
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
 
 // Definisikan path absolut yang kokoh untuk menghindari masalah lingkungan
 $root_path = realpath(__DIR__ . '/..');
@@ -9,6 +6,7 @@ $root_path = realpath(__DIR__ . '/..');
 define('FCPATH', $root_path . '/');
 define('BASEPATH', FCPATH . 'system/');
 define('APPPATH', FCPATH . 'application/');
+define('VIEWPATH', APPPATH . 'views/'); // Tambahkan definisi VIEWPATH
 define('ENVIRONMENT', $_ENV['CI_ENV'] ?? 'production');
 
 // Ubah direktori kerja ke direktori root proyek


### PR DESCRIPTION
Titik masuk webhook kustom (`bot/index.php`) melakukan bootstrap kerangka kerja CodeIgniter tetapi gagal mendefinisikan konstanta `VIEWPATH`. Konstanta ini diperlukan oleh komponen inti CodeIgniter (khususnya handler Pengecualian), dan ketiadaannya menyebabkan kesalahan fatal yang mengakibatkan respons "500 Internal Server Error" ke Telegram.

Dengan mendefinisikan `VIEWPATH` di samping konstanta path inti lainnya, skrip sekarang menyediakan lingkungan yang diperlukan agar CodeIgniter berjalan dengan benar, menyelesaikan kesalahan fatal.

Baris debugging sementara untuk pelaporan kesalahan juga telah dihapus.