### PR TITLE
fix: Resolve E_DEPRECATED warning in Pagination library

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -523,7 +523,7 @@ class CI_Pagination {
 		}
 
 		// If something isn't quite right, back to the default base page.
-		if ( ! ctype_digit($this->cur_page) OR ($this->use_page_numbers && (int) $this->cur_page === 0))
+		if ( ! ctype_digit((string) $this->cur_page) OR ($this->use_page_numbers && (int) $this->cur_page === 0))
 		{
 			$this->cur_page = $base_page;
 		}


### PR DESCRIPTION
Patches the CodeIgniter Pagination library to prevent a PHP E_DEPRECATED warning. The ctype_digit() function was being called with a null value when no page number was present in the URL.

This is fixed by casting the page number variable to a string before the function call, which safely handles the null case without altering the pagination logic.