### PR TITLE
fix: Ensure database migration compatibility with SQLite

### DIFF
--- a/application/migrations/20250807133000_add_status_to_users_table.php
+++ b/application/migrations/20250807133000_add_status_to_users_table.php
@@ -7,10 +7,10 @@ class Migration_Add_status_to_users_table extends CI_Migration {
     {
         $fields = array(
             'status' => array(
-                'type' => "ENUM('active', 'banned')",
+                'type' => 'TEXT',
+                'constraint' => 20,
                 'default' => 'active',
-                'null' => FALSE,
-                'after' => 'last_name' // Meletakkan kolom setelah 'last_name'
+                'null' => FALSE
             )
         );
         $this->dbforge->add_column('users', $fields);

--- a/application/migrations/20250807133001_create_broadcasts_table.php
+++ b/application/migrations/20250807133001_create_broadcasts_table.php
@@ -17,7 +17,8 @@ class Migration_Create_broadcasts_table extends CI_Migration {
                 'null' => FALSE
             ),
             'status' => array(
-                'type' => "ENUM('pending', 'processing', 'completed', 'failed')",
+                'type' => 'TEXT',
+                'constraint' => 20,
                 'default' => 'pending',
                 'null' => FALSE
             ),


### PR DESCRIPTION
Replaces the use of the ENUM data type with TEXT in database migration files. The ENUM type is specific to MySQL and was causing syntax errors when running migrations on the project's SQLite database.

This change ensures the migrations are compatible and can run successfully.