### PR TITLE
fix: Make database migrations idempotent

### DIFF
--- a/application/migrations/20250807133000_add_status_to_users_table.php
+++ b/application/migrations/20250807133000_add_status_to_users_table.php
@@ -5,16 +5,19 @@ class Migration_Add_status_to_users_table extends CI_Migration {
 
     public function up()
     {
-        $fields = array(
-            'status' => array(
-                'type' => 'TEXT',
-                'constraint' => 20,
-                'default' => 'active',
-                'null' => FALSE
-            )
-        );
-        $this->dbforge->add_column('users', $fields);
-        $this->db->query('CREATE INDEX status_index ON users(status)');
+        if (!$this->db->field_exists('status', 'users'))
+        {
+            $fields = array(
+                'status' => array(
+                    'type' => 'TEXT',
+                    'constraint' => 20,
+                    'default' => 'active',
+                    'null' => FALSE
+                )
+            );
+            $this->dbforge->add_column('users', $fields);
+            $this->db->query('CREATE INDEX status_index ON users(status)');
+        }
     }
 
     public function down()

--- a/application/migrations/20250807133001_create_broadcasts_table.php
+++ b/application/migrations/20250807133001_create_broadcasts_table.php
@@ -5,57 +5,60 @@ class Migration_Create_broadcasts_table extends CI_Migration {
 
     public function up()
     {
-        $this->dbforge->add_field(array(
-            'id' => array(
-                'type' => 'INT',
-                'constraint' => 11,
-                'unsigned' => TRUE,
-                'auto_increment' => TRUE
-            ),
-            'message' => array(
-                'type' => 'TEXT',
-                'null' => FALSE
-            ),
-            'status' => array(
-                'type' => 'TEXT',
-                'constraint' => 20,
-                'default' => 'pending',
-                'null' => FALSE
-            ),
-            'total_recipients' => array(
-                'type' => 'INT',
-                'constraint' => 11,
-                'unsigned' => TRUE,
-                'default' => 0
-            ),
-            'sent_count' => array(
-                'type' => 'INT',
-                'constraint' => 11,
-                'unsigned' => TRUE,
-                'default' => 0
-            ),
-            'failed_count' => array(
-                'type' => 'INT',
-                'constraint' => 11,
-                'unsigned' => TRUE,
-                'default' => 0
-            ),
-            'created_at' => array(
-                'type' => 'TIMESTAMP',
-                'default' => 'CURRENT_TIMESTAMP'
-            ),
-            'processing_started_at' => array(
-                'type' => 'DATETIME',
-                'null' => TRUE
-            ),
-            'completed_at' => array(
-                'type' => 'DATETIME',
-                'null' => TRUE
-            ),
-        ));
-        $this->dbforge->add_key('id', TRUE);
-        $this->dbforge->create_table('broadcasts');
-        $this->db->query('CREATE INDEX status_index ON broadcasts(status)');
+        if (!$this->db->table_exists('broadcasts'))
+        {
+            $this->dbforge->add_field(array(
+                'id' => array(
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'unsigned' => TRUE,
+                    'auto_increment' => TRUE
+                ),
+                'message' => array(
+                    'type' => 'TEXT',
+                    'null' => FALSE
+                ),
+                'status' => array(
+                    'type' => 'TEXT',
+                    'constraint' => 20,
+                    'default' => 'pending',
+                    'null' => FALSE
+                ),
+                'total_recipients' => array(
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'unsigned' => TRUE,
+                    'default' => 0
+                ),
+                'sent_count' => array(
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'unsigned' => TRUE,
+                    'default' => 0
+                ),
+                'failed_count' => array(
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'unsigned' => TRUE,
+                    'default' => 0
+                ),
+                'created_at' => array(
+                    'type' => 'TIMESTAMP',
+                    'default' => 'CURRENT_TIMESTAMP'
+                ),
+                'processing_started_at' => array(
+                    'type' => 'DATETIME',
+                    'null' => TRUE
+                ),
+                'completed_at' => array(
+                    'type' => 'DATETIME',
+                    'null' => TRUE
+                ),
+            ));
+            $this->dbforge->add_key('id', TRUE);
+            $this->dbforge->create_table('broadcasts');
+            $this->db->query('CREATE INDEX status_index ON broadcasts(status)');
+        }
     }
 
     public function down()

--- a/application/migrations/20250807134500_add_segmentation_to_users_table.php
+++ b/application/migrations/20250807134500_add_segmentation_to_users_table.php
@@ -5,22 +5,20 @@ class Migration_Add_segmentation_to_users_table extends CI_Migration {
 
     public function up()
     {
-        $fields = array(
-            'tags' => array(
-                'type' => 'TEXT',
-                'null' => TRUE,
-                'after' => 'status'
-            ),
-            'is_test_user' => array(
-                'type' => 'TINYINT',
-                'constraint' => 1,
-                'default' => 0,
-                'null' => FALSE,
-                'after' => 'tags'
-            )
-        );
-        $this->dbforge->add_column('users', $fields);
-        $this->db->query('CREATE INDEX is_test_user_index ON users(is_test_user)');
+        if (!$this->db->field_exists('tags', 'users'))
+        {
+            $tags_field = ['tags' => ['type' => 'TEXT', 'null' => TRUE]];
+            $this->dbforge->add_column('users', $tags_field);
+        }
+
+        if (!$this->db->field_exists('is_test_user', 'users'))
+        {
+            $test_user_field = [
+                'is_test_user' => ['type' => 'TINYINT', 'constraint' => 1, 'default' => 0, 'null' => FALSE]
+            ];
+            $this->dbforge->add_column('users', $test_user_field);
+            $this->db->query('CREATE INDEX is_test_user_index ON users(is_test_user)');
+        }
     }
 
     public function down()

--- a/application/migrations/20250807134600_add_targeting_to_broadcasts_table.php
+++ b/application/migrations/20250807134600_add_targeting_to_broadcasts_table.php
@@ -5,22 +5,19 @@ class Migration_Add_targeting_to_broadcasts_table extends CI_Migration {
 
     public function up()
     {
-        $fields = array(
-            'target_tag' => array(
-                'type' => 'VARCHAR',
-                'constraint' => 255,
-                'null' => TRUE, // NULL berarti semua pengguna
-                'after' => 'message'
-            ),
-            'is_test_broadcast' => array(
-                'type' => 'TINYINT',
-                'constraint' => 1,
-                'default' => 0,
-                'null' => FALSE,
-                'after' => 'target_tag'
-            )
-        );
-        $this->dbforge->add_column('broadcasts', $fields);
+        if (!$this->db->field_exists('target_tag', 'broadcasts'))
+        {
+            $target_tag_field = ['target_tag' => ['type' => 'VARCHAR', 'constraint' => 255, 'null' => TRUE]];
+            $this->dbforge->add_column('broadcasts', $target_tag_field);
+        }
+
+        if (!$this->db->field_exists('is_test_broadcast', 'broadcasts'))
+        {
+            $is_test_broadcast_field = [
+                'is_test_broadcast' => ['type' => 'TINYINT', 'constraint' => 1, 'default' => 0, 'null' => FALSE]
+            ];
+            $this->dbforge->add_column('broadcasts', $is_test_broadcast_field);
+        }
     }
 
     public function down()

--- a/application/migrations/20250807135000_add_error_to_broadcasts_table.php
+++ b/application/migrations/20250807135000_add_error_to_broadcasts_table.php
@@ -5,14 +5,16 @@ class Migration_Add_error_to_broadcasts_table extends CI_Migration {
 
     public function up()
     {
-        $fields = array(
-            'last_error_message' => array(
-                'type' => 'TEXT',
-                'null' => TRUE,
-                'after' => 'failed_count'
-            )
-        );
-        $this->dbforge->add_column('broadcasts', $fields);
+        if (!$this->db->field_exists('last_error_message', 'broadcasts'))
+        {
+            $fields = array(
+                'last_error_message' => array(
+                    'type' => 'TEXT',
+                    'null' => TRUE
+                )
+            );
+            $this->dbforge->add_column('broadcasts', $fields);
+        }
     }
 
     public function down()


### PR DESCRIPTION
Updates all recent database migration files to be idempotent. Each migration now checks if a table or column already exists before attempting to create or add it.

This prevents errors when re-running migrations after a partial failure, making the process more robust.