### PR TITLE
fix: Correct route for UserManagement controller

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -70,7 +70,7 @@ $route['dashboard/broadcast'] = 'dashboard/broadcast';
 $route['dashboard/send_broadcast'] = 'dashboard/send_broadcast';
 
 // Rute untuk Manajemen Pengguna
-$route['user_management'] = 'user_management';
-$route['user_management/index'] = 'user_management/index';
-$route['user_management/edit/(:num)'] = 'user_management/edit/$1';
-$route['user_management/update/(:num)'] = 'user_management/update/$1';
+$route['user_management'] = 'UserManagement';
+$route['user_management/index'] = 'UserManagement/index';
+$route['user_management/edit/(:num)'] = 'UserManagement/edit/$1';
+$route['user_management/update/(:num)'] = 'UserManagement/update/$1';


### PR DESCRIPTION
Fixes a 404 error for the User Management page. The route was implicitly trying to find a lowercase controller name ('user_management'), which can fail on case-sensitive systems.

The fix makes the route explicit by pointing to the correct 'UserManagement' controller class name, ensuring the page is always found.