### PR TITLE
feat: Add /subscribe and /unsubscribe commands

### DIFF
--- a/application/models/UserModel.php
+++ b/application/models/UserModel.php
@@ -64,20 +64,36 @@ class UserModel extends CI_Model {
     }
 
     /**
-     * Menandai pengguna sebagai diblokir.
+     * Menetapkan status spesifik untuk pengguna.
+     * @param int $chat_id
+     * @param string $status Status baru ('active', 'banned', 'unsubscribed')
+     * @return bool
      */
-    public function markUserAsBanned($chat_id) {
+    public function setUserStatus($chat_id, $status) {
+        // Validasi status untuk keamanan
+        $allowed_statuses = ['active', 'banned', 'unsubscribed'];
+        if (!in_array($status, $allowed_statuses)) {
+            return FALSE;
+        }
         $this->db->where('chat_id', $chat_id);
-        return $this->db->update('users', ['status' => 'banned']);
+        return $this->db->update('users', ['status' => $status]);
     }
 
     /**
-     * Mendapatkan statistik tentang pengguna (aktif vs diblokir).
+     * Menandai pengguna sebagai diblokir.
+     */
+    public function markUserAsBanned($chat_id) {
+        return $this->setUserStatus($chat_id, 'banned');
+    }
+
+    /**
+     * Mendapatkan statistik tentang pengguna (aktif, diblokir, berhenti langganan).
      */
     public function getUserStats() {
         $this->db->select("COUNT(id) as total_users");
         $this->db->select("COUNT(CASE WHEN status = 'active' THEN 1 END) as active_users");
         $this->db->select("COUNT(CASE WHEN status = 'banned' THEN 1 END) as banned_users");
+        $this->db->select("COUNT(CASE WHEN status = 'unsubscribed' THEN 1 END) as unsubscribed_users");
         $query = $this->db->get('users');
         return $query->row_array();
     }

--- a/application/views/log_view.php
+++ b/application/views/log_view.php
@@ -67,26 +67,34 @@
         <!-- Bagian Statistik Pengguna -->
         <h2 class="h4 mb-3">Statistik Pengguna</h2>
         <div class="row">
-            <div class="col-lg-4">
+            <div class="col-lg-3">
                 <div class="card text-white bg-success mb-4">
                     <div class="card-body">
-                        <h5 class="card-title"><i class="bi bi-person-check-fill"></i> Pengguna Aktif</h5>
+                        <h5 class="card-title"><i class="bi bi-person-check-fill"></i> Aktif</h5>
                         <p class="card-text fs-4"><?= number_format($user_stats['active_users'] ?? 0) ?></p>
                     </div>
                 </div>
             </div>
-            <div class="col-lg-4">
+            <div class="col-lg-3">
+                <div class="card text-white bg-warning mb-4">
+                    <div class="card-body">
+                        <h5 class="card-title"><i class="bi bi-person-dash-fill"></i> Berhenti</h5>
+                        <p class="card-text fs-4"><?= number_format($user_stats['unsubscribed_users'] ?? 0) ?></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-3">
                 <div class="card text-white bg-danger mb-4">
                     <div class="card-body">
-                        <h5 class="card-title"><i class="bi bi-person-x-fill"></i> Pengguna Diblokir</h5>
+                        <h5 class="card-title"><i class="bi bi-person-x-fill"></i> Diblokir</h5>
                         <p class="card-text fs-4"><?= number_format($user_stats['banned_users'] ?? 0) ?></p>
                     </div>
                 </div>
             </div>
-            <div class="col-lg-4">
+            <div class="col-lg-3">
                 <div class="card text-white bg-secondary mb-4">
                     <div class="card-body">
-                        <h5 class="card-title"><i class="bi bi-people-fill"></i> Total Pengguna</h5>
+                        <h5 class="card-title"><i class="bi bi-people-fill"></i> Total</h5>
                         <p class="card-text fs-4"><?= number_format($user_stats['total_users'] ?? 0) ?></p>
                     </div>
                 </div>

--- a/application/views/user_management_view.php
+++ b/application/views/user_management_view.php
@@ -55,7 +55,17 @@
                                 <td><?= html_escape(trim($user['first_name'] . ' ' . $user['last_name'])) ?></td>
                                 <td><?= $user['username'] ? '@' . html_escape($user['username']) : '' ?></td>
                                 <td>
-                                    <span class="badge bg-<?= $user['status'] === 'active' ? 'success' : 'danger' ?> status-badge"><?= $user['status'] ?></span>
+                                    <?php
+                                        $status_class = 'secondary'; // Fallback
+                                        if ($user['status'] === 'active') {
+                                            $status_class = 'success';
+                                        } elseif ($user['status'] === 'banned') {
+                                            $status_class = 'danger';
+                                        } elseif ($user['status'] === 'unsubscribed') {
+                                            $status_class = 'warning';
+                                        }
+                                    ?>
+                                    <span class="badge bg-<?= $status_class ?> status-badge"><?= $user['status'] ?></span>
                                 </td>
                                 <td>
                                     <?php if(!empty($user['tags'])): ?>

--- a/bot/BotHandler.php
+++ b/bot/BotHandler.php
@@ -88,11 +88,21 @@ class BotHandler
 
         switch ($command) {
             case '/start':
-                $responseText = "Halo! Selamat datang di bot PHP modular.\n\nBerikut beberapa hal yang dapat saya lakukan:\n- Saya akan menggemakan pesan Anda kembali.\n- Coba kirim kata 'halo' atau 'info'.\n\nKetik /help untuk melihat daftar lengkap perintah.";
+                $responseText = "Halo! Selamat datang di bot PHP modular.\n\nKetik /help untuk melihat daftar perintah.";
                 break;
 
             case '/help':
-                $responseText = "Bantuan Bot:\n\n/start - Memulai bot dan menampilkan pesan selamat datang.\n/help - Menampilkan pesan bantuan ini.\n\nSelain perintah, saya dapat membalas kata kunci tertentu. Coba kirim 'info'!";
+                $responseText = "Bantuan Bot:\n\n/start - Memulai bot.\n/help - Menampilkan pesan bantuan ini.\n/subscribe - Mengaktifkan kembali langganan siaran.\n/unsubscribe - Berhenti berlangganan dari semua siaran.";
+                break;
+
+            case '/subscribe':
+                $this->userModel->setUserStatus($chatId, 'active');
+                $responseText = "Terima kasih! Anda telah kembali berlangganan dan akan menerima siaran berikutnya.";
+                break;
+
+            case '/unsubscribe':
+                $this->userModel->setUserStatus($chatId, 'unsubscribed');
+                $responseText = "Anda telah berhasil berhenti berlangganan dari pesan siaran. Anda tidak akan menerima siaran lagi kecuali Anda mengetik /subscribe.";
                 break;
 
             default:


### PR DESCRIPTION
This commit introduces /subscribe and /unsubscribe commands, allowing users to opt-out of and opt-in to receiving broadcast messages.

Key Changes:

1.  **Bot Commands:**
    -   The `BotHandler` now processes `/subscribe` and `/unsubscribe` commands.
    -   These commands update the user's status to 'active' or 'unsubscribed' respectively and send a confirmation message.

2.  **User Model:**
    -   A generic `setUserStatus()` method has been added to `UserModel` to handle status changes.
    -   The `getUserStats()` method has been updated to include a count of 'unsubscribed' users.

3.  **Dashboard UI:**
    -   The main dashboard now displays a new stat card for "Unsubscribed" users.
    -   The User Management page now displays a distinct warning badge for users with the 'unsubscribed' status.