### PR TITLE
fix: Load Settings_model in Dashboard to prevent fatal error

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -10,6 +10,7 @@ class Dashboard extends CI_Controller {
         $this->load->model('KeywordModel');
         $this->load->model('UserModel');
         $this->load->model('BroadcastModel');
+        $this->load->model('Settings_model');
         $this->load->library('pagination');
         $this->load->helper('url');
         $this->load->helper('form');


### PR DESCRIPTION
Fixes a fatal error on the main dashboard page caused by calling a method on a null object. The Settings_model was being used to fetch bot health stats without being loaded in the controller's constructor first. This commit adds the missing model load statement.