### PR TITLE
refactor: Store cron secret key in database instead of .env

### DIFF
--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -5,16 +5,14 @@ class Cron extends CI_Controller {
 
     public function __construct() {
         parent::__construct();
-        // Memuat environment variables
-        $dotenv = Dotenv\Dotenv::createImmutable(FCPATH);
-        $dotenv->load();
+        $this->load->model('Settings_model');
     }
 
     /**
      * Menjalankan skrip cron job siaran dengan validasi token.
      */
     public function run() {
-        $cron_secret = $_ENV['CRON_SECRET_KEY'] ?? NULL;
+        $cron_secret = $this->Settings_model->get_setting('cron_secret_key');
         $token = $this->input->get('token');
 
         // Validasi token untuk keamanan

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -197,6 +197,7 @@ class Dashboard extends CI_Controller {
         $data['user_stats'] = $this->UserModel->getUserStats();
         $data['tags'] = $this->UserModel->getAllTags();
         $data['filters'] = $filters;
+        $data['cron_secret_key'] = $this->Settings_model->get_setting('cron_secret_key');
 
         $this->load->view('broadcast_view', $data);
     }
@@ -299,36 +300,13 @@ class Dashboard extends CI_Controller {
     }
 
     /**
-     * Menghasilkan CRON_SECRET_KEY baru dan menyimpannya di file .env.
+     * Menghasilkan CRON_SECRET_KEY baru dan menyimpannya di database.
      */
     public function reset_cron_key()
     {
-        $env_path = FCPATH . '.env';
         $new_key = bin2hex(random_bytes(16)); // 32 karakter hex
-
-        if (is_writable($env_path)) {
-            $env_content = file_get_contents($env_path);
-
-            $key_name = 'CRON_SECRET_KEY';
-
-            if (strpos($env_content, $key_name) !== false) {
-                // Kunci sudah ada, ganti nilainya
-                $env_content = preg_replace(
-                    '/^' . preg_quote($key_name, '/') . '=.*/m',
-                    $key_name . '="' . $new_key . '"',
-                    $env_content
-                );
-            } else {
-                // Kunci belum ada, tambahkan di akhir
-                $env_content .= "\n\n" . $key_name . '="' . $new_key . '"';
-            }
-
-            file_put_contents($env_path, $env_content);
-            // TODO: Tambahkan flash message sukses
-        } else {
-            // TODO: Tambahkan flash message error (file tidak dapat ditulis)
-        }
-
+        $this->Settings_model->save_setting('cron_secret_key', $new_key);
+        // TODO: Tambahkan flash message sukses
         redirect('dashboard/broadcast');
     }
 }

--- a/application/views/broadcast_view.php
+++ b/application/views/broadcast_view.php
@@ -73,7 +73,7 @@
                         <input type="text" class="form-control form-control-sm mb-3" value="* * * * * /usr/bin/php <?= FCPATH ?>cron/process_broadcasts.php" readonly>
 
                         <label class="form-label small"><strong>Opsi 2: URL Cron Job</strong></label>
-                        <?php $cron_key = $_ENV['CRON_SECRET_KEY'] ?? 'SECRET_KEY_NOT_SET'; ?>
+                        <?php $cron_key = $cron_secret_key ?? 'NOT_SET'; ?>
                         <div class="input-group input-group-sm mb-3">
                             <input type="text" id="cron-url" class="form-control" value="<?= site_url('cron/run?token=') . $cron_key ?>" readonly>
                             <button id="toggle-key-btn" class="btn btn-outline-secondary" type="button"><i class="bi bi-eye"></i></button>
@@ -188,12 +188,14 @@
         const cronUrlInput = document.getElementById('cron-url');
         if (toggleBtn && cronUrlInput) {
             const originalUrl = cronUrlInput.value;
-            const secretKey = "<?= $_ENV['CRON_SECRET_KEY'] ?? '' ?>";
+            const secretKey = "<?= $cron_secret_key ?? '' ?>";
             let keyVisible = false;
 
-            // Initially hide the key
-            if (secretKey) {
+            // Initially hide the key and disable button if not set
+            if (secretKey && secretKey !== 'NOT_SET') {
                 cronUrlInput.value = originalUrl.replace(secretKey, '************');
+            } else {
+                toggleBtn.disabled = true;
             }
 
             toggleBtn.addEventListener('click', () => {


### PR DESCRIPTION
Refactors the cron job secret key storage mechanism to use the database instead of the .env file. This is a better architectural approach, as it centralizes application settings and avoids potential file permission issues with .env.

Changes:
- The `reset_cron_key` function in `Dashboard.php` now saves the key to the `settings` table in the database.
- The `Cron.php` controller now validates the execution token against the key stored in the database.
- The `broadcast_view.php` now receives the key from the controller to display, removing direct dependency on environment variables in the view.