### PR TITLE
fix: Prevent constant already defined warnings in cron script

### DIFF
--- a/cron/process_broadcasts.php
+++ b/cron/process_broadcasts.php
@@ -2,18 +2,20 @@
 // Standalone script to be run by a cron job
 
 // --- 1. Setup & Bootstrap ---
-// This script is now called by the Cron.php controller, which handles security.
+// This script can be called via CLI or included from the Cron controller.
+// We need to bootstrap CodeIgniter only if it hasn't been loaded yet (i.e., when run from CLI).
+if (!defined('FCPATH')) {
+    // Set up paths
+    $root_path = realpath(__DIR__ . '/..');
+    define('FCPATH', $root_path . '/');
+    define('BASEPATH', FCPATH . 'system/');
+    define('APPPATH', FCPATH . 'application/');
+    define('ENVIRONMENT', $_ENV['CI_ENV'] ?? 'production');
 
-// Set up paths
-$root_path = realpath(__DIR__ . '/..');
-define('FCPATH', $root_path . '/');
-define('BASEPATH', FCPATH . 'system/');
-define('APPPATH', FCPATH . 'application/');
-define('ENVIRONMENT', $_ENV['CI_ENV'] ?? 'production');
-
-// Bootstrap CodeIgniter
-chdir(FCPATH);
-require_once BASEPATH . 'core/CodeIgniter.php';
+    // Bootstrap CodeIgniter
+    chdir(FCPATH);
+    require_once BASEPATH . 'core/CodeIgniter.php';
+}
 
 // --- 2. Lock Mechanism ---
 $lock_file = APPPATH . 'logs/broadcast.lock';


### PR DESCRIPTION
Fixes PHP warnings ("Constant already defined") that occurred when running the cron job via the new URL endpoint.

The cron script now checks if CodeIgniter constants like FCPATH are already defined before attempting to define them. This makes the bootstrapping logic conditional, allowing the script to run correctly both from the command line (where it needs to bootstrap) and when included by a controller (where it doesn't).