### PR TITLE
fix: Load URL helper in MY_Controller to fix fatal error

### DIFF
--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -16,6 +16,7 @@ class MY_Controller extends CI_Controller {
     public function __construct() {
         parent::__construct();
 
+        $this->load->helper('url');
         $this->load->library('session');
         $this->load->model('BotModel');
 


### PR DESCRIPTION
Fixes a fatal error ("Call to undefined function redirect()") that occurred in the constructor of MY_Controller. The redirect() function requires the URL helper, which was not being loaded in the base controller.

This commit adds the necessary `$this->load->helper('url');` to the constructor, making the function available and preventing the error.