### PR TITLE
fix: Correct typo in MY_Controller to prevent redirect loop

### DIFF
--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -25,7 +25,7 @@ class MY_Controller extends CI_Controller {
 
         // Jika tidak ada bot sama sekali, paksa redirect ke halaman manajemen bot
         // kecuali jika kita sudah berada di sana.
-        if (empty($this->all_bots) && strtolower($this->uri->segment(1)) !== 'botmanagement') {
+        if (empty($this->all_bots) && strtolower($this->uri->segment(1)) !== 'bot_management') {
             redirect('bot_management');
         }
 


### PR DESCRIPTION
Fixes a "too many redirects" error that occurred when visiting the bot_management page with no bots configured. A typo in a conditional check ('botmanagement' instead of 'bot_management') caused the page to infinitely redirect to itself. This commit corrects the typo.