### PR TITLE
Fix: Create robust migration for keyword_replies table

### DIFF
--- a/application/migrations/20240520120000_refactor_keyword_replies_to_global.php
+++ b/application/migrations/20240520120000_refactor_keyword_replies_to_global.php
@@ -1,0 +1,94 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Refactor_keyword_replies_to_global extends CI_Migration {
+
+    public function up()
+    {
+        $this->db->trans_start();
+
+        // 1. Check if the bot_id column exists. If not, we don't need to do anything.
+        if (!$this->db->field_exists('bot_id', 'keyword_replies'))
+        {
+            $this->db->trans_complete();
+            log_message('info', 'Migration for keyword_replies: bot_id column does not exist, skipping.');
+            return;
+        }
+
+        // 2. Rename old table
+        $this->dbforge->rename_table('keyword_replies', 'keyword_replies_old');
+        log_message('info', 'Renamed keyword_replies to keyword_replies_old');
+
+        // 3. Create the new table with a unique constraint on the keyword
+        $this->dbforge->add_field([
+            'id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => TRUE,
+                'auto_increment' => TRUE
+            ],
+            'keyword' => [
+                'type' => 'VARCHAR',
+                'constraint' => '255',
+                'unique' => TRUE
+            ],
+            'reply' => [
+                'type' => 'TEXT',
+                'null' => FALSE
+            ]
+        ]);
+        $this->dbforge->add_key('id', TRUE);
+        $this->dbforge->create_table('keyword_replies');
+        log_message('info', 'Created new keyword_replies table.');
+
+        // 4. Copy distinct keywords from the old table to the new one.
+        // This query will take the reply from the keyword with the lowest ID in case of duplicates.
+        $query = $this->db->query("
+            INSERT INTO keyword_replies (keyword, reply)
+            SELECT t.keyword, t.reply
+            FROM (
+                SELECT
+                    keyword,
+                    reply,
+                    ROW_NUMBER() OVER(PARTITION BY keyword ORDER BY id ASC) as rn
+                FROM keyword_replies_old
+            ) t
+            WHERE t.rn = 1
+        ");
+        log_message('info', 'Copied ' . $query->affected_rows() . ' distinct keywords to the new table.');
+
+        // 5. Drop the old table
+        $this->dbforge->drop_table('keyword_replies_old');
+        log_message('info', 'Dropped keyword_replies_old table.');
+
+        $this->db->trans_complete();
+
+        if ($this->db->trans_status() === FALSE)
+        {
+            log_message('error', 'Migration for keyword_replies failed.');
+        }
+        else
+        {
+            log_message('info', 'Migration for keyword_replies completed successfully.');
+        }
+    }
+
+    public function down()
+    {
+        // Add the bot_id column back. Data will be lost, but schema is restored.
+        $fields = [
+            'bot_id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => TRUE,
+                'null' => TRUE,
+                'after' => 'id'
+            ]
+        ];
+        // We also need to drop the unique constraint on 'keyword'
+        // This is complex and depends on the DB driver.
+        // For simplicity, we will assume this downgrade path is for emergencies.
+        log_message('warning', "Downgrading 'keyword_replies' will re-add 'bot_id' but won't restore original data or remove unique key constraint automatically.");
+        $this->dbforge->add_column('keyword_replies', $fields);
+    }
+}


### PR DESCRIPTION
This commit addresses a database error caused by an earlier, incompatible migration. The error, "Unsupported feature of the database platform," typically occurs when trying to drop a column in SQLite.

A new, robust migration is introduced to make the `keyword_replies` table global, aligning the database schema with the application logic.

The new migration (`20240520120000_refactor_keyword_replies_to_global.php`):
- Is transactional and safe to re-run.
- Renames the old table instead of using `ALTER TABLE ... DROP COLUMN`.
- Creates a new table with the correct schema, including a unique constraint on the `keyword` column.
- Copies distinct keywords from the old table to the new one, resolving potential duplicates.
- Drops the old table upon successful data migration.

This approach ensures compatibility with SQLite and correctly finalizes the transition to a global keyword system.