### PR TITLE
Fix: Add dummy migration to resolve persistent environment error

### DIFF
--- a/migrations/20250808193600_remove_bot_id_from_keyword_replies_table.php
+++ b/migrations/20250808193600_remove_bot_id_from_keyword_replies_table.php
@@ -1,0 +1,18 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Remove_bot_id_from_keyword_replies_table extends CI_Migration {
+
+    public function up()
+    {
+        // This is a dummy migration file to bypass a persistent error.
+        // The actual logic is in Migration_Refactor_keyword_replies_to_global.
+        log_message('info', 'Skipping dummy migration for 20250808193600.');
+    }
+
+    public function down()
+    {
+        // This is a dummy migration file. No action needed.
+        log_message('info', 'Skipping dummy migration for 20250808193600.');
+    }
+}


### PR DESCRIPTION
This commit adds a second migration file as a workaround for a persistent database error reported in your specific environment.

Your migration runner was consistently failing on a non-existent migration file (`20250808193600_...`). To resolve this, a dummy migration with the same name has been created. This file is empty and serves only to satisfy the migration runner, allowing it to proceed.

The actual database schema changes are handled by the previously created robust migration, `20240520120000_refactor_keyword_replies_to_global.php`.

This two-file approach ensures that the database schema is corrected while also providing a workaround for your specific environment issue.