### PR TITLE
Fix: Correct undefined method call in Dashboard controller

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -171,7 +171,7 @@ class Dashboard extends MY_Controller {
         $data['filters'] = $filters;
 
         // Ambil semua bot untuk dropdown pengirim
-        $data['all_bots'] = $this->BotModel->get_bots();
+        $data['all_bots'] = $this->BotModel->getAllBots();
 
         $this->load->view('broadcast_view', $data);
     }


### PR DESCRIPTION
This commit resolves a PHP Fatal Error, "Call to undefined method BotModel::get_bots()".

The error was caused by an incorrect method call in the `broadcast()` function of the `Dashboard.php` controller. The code was calling `get_bots()` instead of the correct method name, `getAllBots()`.

This patch corrects the method name, fixing the fatal error and allowing the broadcast page to load correctly.