### PR TITLE
This commit includes two separate fixes:

### DIFF
--- a/application/migrations/20250808193600_remove_bot_id_from_keyword_replies_table.php
+++ b/application/migrations/20250808193600_remove_bot_id_from_keyword_replies_table.php
@@ -7,7 +7,10 @@ class Migration_Remove_bot_id_from_keyword_replies_table extends CI_Migration {
     {
         if ($this->db->field_exists('bot_id', 'keyword_replies'))
         {
-            $this->dbforge->drop_column('keyword_replies', 'bot_id');
+            // $this->dbforge->drop_column('keyword_replies', 'bot_id');
+            // Dropping columns is not supported by the SQLite3 driver.
+            // This migration is being bypassed to prevent errors. The column will remain in the database,
+            // but it is unused by the application.
         }
     }
 


### PR DESCRIPTION
1.  **Fix: Initialize selected_bot_id to prevent undefined property error**

    The `UserManagement` controller was throwing an "Undefined property" warning because it was accessing `$this->selected_bot_id` without it being initialized.

    This is fixed by:
    - Adding logic to `MY_Controller` to initialize `$this->selected_bot_id` for all controllers that extend it. The ID is retrieved from the session or defaults to the first available bot.
    - Adding a `switch_bot` method to `BotManagement` to allow you to change the active bot.

2.  **Fix: Bypass unsupported drop_column in migration for SQLite**

    A database migration was failing on SQLite because it uses `drop_column`, which is not supported by the SQLite3 driver in CodeIgniter.

    This is fixed by:
    - Commenting out the `drop_column` call in the migration file `20250808193600_remove_bot_id_from_keyword_replies_table.php`.
    - Adding a comment to explain the workaround. This allows the migration to run without error.