### PR TITLE
This commit includes fixes for three separate issues:

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -19,15 +19,22 @@ class Dashboard extends MY_Controller {
 
     public function index()
     {
-        // Ambil filter dari URL, termasuk filter bot baru
+        // Gunakan bot yang dipilih dari sesi sebagai default
+        $bot_id_to_use = $this->input->get('bot_id') ?: $this->selected_bot_id;
+
+        // Ambil filter dari URL
         $filters = [
-            'bot_id'    => $this->input->get('bot_id'),
+            'bot_id'    => $bot_id_to_use, // Gunakan bot_id yang sudah ditentukan
             'log_type'  => $this->input->get('log_type'),
             'chat_id'   => $this->input->get('chat_id'),
             'chat_name' => $this->input->get('chat_name'),
             'keyword'   => $this->input->get('keyword')
         ];
         $filters = array_filter($filters, function($value) { return $value !== null && $value !== ''; });
+
+        // Ambil detail bot yang dipilih untuk ditampilkan di header
+        $data['selected_bot'] = $this->BotModel->getBotById($bot_id_to_use);
+
 
         // Konfigurasi Paginasi
         $config['base_url'] = site_url('dashboard/index');


### PR DESCRIPTION
1.  **Fix: Initialize selected_bot_id to prevent undefined property error**

    The `UserManagement` controller was throwing an "Undefined property" warning because it was accessing `$this->selected_bot_id` without it being initialized.

    This is fixed by:
    - Adding logic to `MY_Controller` to initialize `$this->selected_bot_id` for all controllers that extend it. The ID is retrieved from the session or defaults to the first available bot.
    - Adding a `switch_bot` method to `BotManagement` to allow you to change the active bot.

2.  **Fix: Bypass unsupported drop_column in migration for SQLite**

    A database migration was failing on SQLite because it uses `drop_column`, which is not supported by the SQLite3 driver in CodeIgniter.

    This is fixed by:
    - Commenting out the `drop_column` call in the migration file `20250808193600_remove_bot_id_from_keyword_replies_table.php`.

3.  **Fix: Ensure dashboard uses selected bot from session**

    The dashboard was showing a "Tidak ada bot" (No bot) message because it did not respect the globally selected bot ID from the session.

    This is fixed by:
    - Modifying the `Dashboard` controller to use the `selected_bot_id` from the session as a fallback.
    - Ensuring the selected bot's details are loaded and passed to the view.