### PR TITLE
This commit includes fixes for three separate issues:

### DIFF
--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -10,6 +10,7 @@ class MY_Controller extends CI_Controller {
 
     protected $all_bots;
     protected $selected_bot_id;
+    protected $selected_bot;
 
     public function __construct() {
         parent::__construct();
@@ -29,16 +30,24 @@ class MY_Controller extends CI_Controller {
         // Logika untuk menentukan bot yang dipilih
         $this->selected_bot_id = $this->session->userdata('selected_bot_id');
 
+        // Jika tidak ada bot yang dipilih di session DAN ada bot tersedia, gunakan bot pertama sebagai default
         if (!$this->selected_bot_id && !empty($this->all_bots)) {
-            // Jika tidak ada bot yang dipilih di session, gunakan bot pertama sebagai default
             $this->selected_bot_id = $this->all_bots[0]['id'];
             $this->session->set_userdata('selected_bot_id', $this->selected_bot_id);
         }
 
-        // Jadikan daftar bot dan bot yang dipilih tersedia secara global untuk semua view
+        // Muat data bot yang dipilih
+        if ($this->selected_bot_id) {
+            $this->selected_bot = $this->BotModel->getBotById($this->selected_bot_id);
+        } else {
+            $this->selected_bot = null;
+        }
+
+        // Jadikan variabel global untuk semua view
         $this->load->vars([
             'all_bots' => $this->all_bots,
-            'selected_bot_id' => $this->selected_bot_id
+            'selected_bot_id' => $this->selected_bot_id,
+            'selected_bot' => $this->selected_bot
         ]);
     }
 }


### PR DESCRIPTION
1.  **Fix: Initialize selected_bot_id to prevent undefined property error**

    The `UserManagement` controller was throwing an "Undefined property" warning because it was accessing `$this->selected_bot_id` without it being initialized.

    This is fixed by:
    - Adding logic to `MY_Controller` to initialize `$this->selected_bot_id` and the full `$selected_bot` object for all controllers that extend it. The ID is retrieved from the session or defaults to the first available bot.
    - Adding a `switch_bot` method to `BotManagement` to allow users to change the active bot.

2.  **Fix: Bypass unsupported drop_column in migration for SQLite**

    A database migration was failing on SQLite because it uses `drop_column`, which is not supported by the SQLite3 driver in CodeIgniter.

    This is fixed by:
    - Commenting out the `drop_column` call in the migration file `20250808193600_remove_bot_id_from_keyword_replies_table.php`.

3.  **Fix: Ensure dashboard uses selected bot from session**

    The dashboard was showing a "Tidak ada bot" (No bot) message because it did not respect the globally selected bot ID from the session.

    This is fixed by:
    - Modifying the `Dashboard` controller to use the `selected_bot_id` from the session as a fallback.
    - Ensuring the selected bot's details are loaded and passed to the view.