### PR TITLE
feat: Add bot info modal to edit page

### DIFF
--- a/application/controllers/Bot_api.php
+++ b/application/controllers/Bot_api.php
@@ -1,0 +1,80 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Bot_api extends MY_Controller {
+
+    public function __construct() {
+        parent::__construct();
+        $this->load->model('BotModel');
+        $this->load->helper('url');
+    }
+
+    private function _send_telegram_request($token, $method, $params = []) {
+        $url = "https://api.telegram.org/bot{$token}/{$method}";
+
+        $options = [
+            'http' => [
+                'method' => 'GET',
+                'header' => "Content-Type: application/x-www-form-urlencoded\r\n",
+                'ignore_errors' => true,
+            ],
+        ];
+
+        if (!empty($params)) {
+            $url .= '?' . http_build_query($params);
+        }
+
+        $context = stream_context_create($options);
+        $response = file_get_contents($url, false, $context);
+
+        return json_decode($response, true);
+    }
+
+    public function info($bot_id) {
+        $bot = $this->BotModel->getBotById($bot_id);
+        if (!$bot) {
+            $this->output->set_status_header(404)->set_content_type('application/json')->set_output(json_encode(['ok' => false, 'error' => 'Bot not found']));
+            return;
+        }
+
+        $token = $bot['token'];
+
+        $getMe_result = $this->_send_telegram_request($token, 'getMe');
+        $getWebhookInfo_result = $this->_send_telegram_request($token, 'getWebhookInfo');
+
+        $response_data = [
+            'getMe' => $getMe_result,
+            'getWebhookInfo' => $getWebhookInfo_result,
+        ];
+
+        $this->output->set_content_type('application/json')->set_output(json_encode($response_data));
+    }
+
+    public function set_webhook($bot_id) {
+        $bot = $this->BotModel->getBotById($bot_id);
+        if (!$bot) {
+            $this->output->set_status_header(404)->set_content_type('application/json')->set_output(json_encode(['ok' => false, 'error' => 'Bot not found']));
+            return;
+        }
+
+        $token = $bot['token'];
+        $webhook_url = site_url('bot_webhook/handle/' . $bot['id']);
+
+        $result = $this->_send_telegram_request($token, 'setWebhook', ['url' => $webhook_url]);
+
+        $this->output->set_content_type('application/json')->set_output(json_encode($result));
+    }
+
+    public function delete_webhook($bot_id) {
+        $bot = $this->BotModel->getBotById($bot_id);
+        if (!$bot) {
+            $this->output->set_status_header(404)->set_content_type('application/json')->set_output(json_encode(['ok' => false, 'error' => 'Bot not found']));
+            return;
+        }
+
+        $token = $bot['token'];
+        $result = $this->_send_telegram_request($token, 'deleteWebhook');
+
+        $this->output->set_content_type('application/json')->set_output(json_encode($result));
+    }
+}

--- a/application/views/bot_edit_view.php
+++ b/application/views/bot_edit_view.php
@@ -18,9 +18,117 @@
                 <hr>
                 <button type="submit" class="btn btn-primary">Simpan Perubahan</button>
                 <a href="<?= site_url('bot_management') ?>" class="btn btn-secondary">Batal</a>
+                <button type="button" id="check-info-btn" class="btn btn-info" data-bs-toggle="modal" data-bs-target="#botInfoModal">Cek Info Bot</button>
             <?= form_close() ?>
         </div>
     </div>
 </div>
+
+<!-- Modal -->
+<div class="modal fade" id="botInfoModal" tabindex="-1" aria-labelledby="botInfoModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="botInfoModalLabel">Informasi Bot</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="info-spinner" class="text-center">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+        </div>
+        <div id="info-content" style="display: none;">
+            <p><strong>Info Dasar (getMe):</strong></p>
+            <pre id="getMeInfo"></pre>
+            <p><strong>Info Webhook (getWebhookInfo):</strong></p>
+            <pre id="getWebhookInfo"></pre>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Tutup</button>
+        <button type="button" id="set-webhook-btn" class="btn btn-success">Set Webhook</button>
+        <button type="button" id="delete-webhook-btn" class="btn btn-danger">Hapus Webhook</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const botId = <?= $bot['id'] ?>;
+    const infoModalEl = document.getElementById('botInfoModal');
+
+    const getMeInfoElem = document.getElementById('getMeInfo');
+    const getWebhookInfoElem = document.getElementById('getWebhookInfo');
+    const infoSpinner = document.getElementById('info-spinner');
+    const infoContent = document.getElementById('info-content');
+
+    const setWebhookBtn = document.getElementById('set-webhook-btn');
+    const deleteWebhookBtn = document.getElementById('delete-webhook-btn');
+
+    async function fetchBotInfo() {
+        infoSpinner.style.display = 'block';
+        infoContent.style.display = 'none';
+
+        try {
+            const response = await fetch(`<?= site_url('bot_api/info/') ?>${botId}`);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const data = await response.json();
+
+            getMeInfoElem.textContent = JSON.stringify(data.getMe, null, 2);
+            getWebhookInfoElem.textContent = JSON.stringify(data.getWebhookInfo, null, 2);
+
+        } catch (error) {
+            getMeInfoElem.textContent = 'Gagal memuat data.';
+            getWebhookInfoElem.textContent = 'Gagal memuat data. Error: ' + error.message;
+        } finally {
+            infoSpinner.style.display = 'none';
+            infoContent.style.display = 'block';
+        }
+    }
+
+    infoModalEl.addEventListener('show.bs.modal', function (event) {
+        fetchBotInfo();
+    });
+
+    setWebhookBtn.addEventListener('click', async function() {
+        this.disabled = true;
+        this.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...';
+        try {
+            const response = await fetch(`<?= site_url('bot_api/set_webhook/') ?>${botId}`);
+            const result = await response.json();
+            alert(result.ok ? 'Webhook berhasil di-set!' : `Gagal: ${result.description || 'Unknown error'}`);
+            await fetchBotInfo(); // Refresh info
+        } catch (error) {
+            alert('Terjadi kesalahan saat set webhook: ' + error.message);
+        } finally {
+            this.disabled = false;
+            this.innerHTML = 'Set Webhook';
+        }
+    });
+
+    deleteWebhookBtn.addEventListener('click', async function() {
+        if (!confirm('Apakah Anda yakin ingin menghapus webhook?')) {
+            return;
+        }
+        this.disabled = true;
+        this.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...';
+        try {
+            const response = await fetch(`<?= site_url('bot_api/delete_webhook/') ?>${botId}`);
+            const result = await response.json();
+            alert(result.ok ? 'Webhook berhasil dihapus!' : `Gagal: ${result.description || 'Unknown error'}`);
+            await fetchBotInfo(); // Refresh info
+        } catch (error) {
+            alert('Terjadi kesalahan saat menghapus webhook: ' + error.message);
+        } finally {
+            this.disabled = false;
+            this.innerHTML = 'Hapus Webhook';
+        }
+    });
+});
+</script>
 
 <?php $this->load->view('templates/footer'); ?>


### PR DESCRIPTION
This change introduces a new feature on the bot edit page that allows you to view detailed information about your bot directly from the Telegram API.

- A "Check Info" button is added to the bot edit page.
- Clicking this button opens a modal that displays the results of `getMe` and `getWebhookInfo` API calls.
- The modal also includes buttons to "Set Webhook" and "Delete Webhook", allowing for easy management of the bot's webhook.
- A new controller, `Bot_api.php`, is created to handle the backend interactions with the Telegram API.