### PR TITLE
feat: Add route for reset_cron_key

### DIFF
--- a/application/migrations/20250806124518_create_settings_table.php
+++ b/application/migrations/20250806124518_create_settings_table.php
@@ -15,7 +15,6 @@ class Migration_Create_settings_table extends CI_Migration {
             'key' => array(
                 'type' => 'VARCHAR',
                 'constraint' => '255',
-                'unique' => TRUE,
             ),
             'value' => array(
                 'type' => 'TEXT',

--- a/application/migrations/20250808124005_add_bot_id_to_settings_table.php
+++ b/application/migrations/20250808124005_add_bot_id_to_settings_table.php
@@ -17,8 +17,8 @@ class Migration_Add_bot_id_to_settings_table extends CI_Migration {
             );
             $this->dbforge->add_column('settings', $fields);
 
-            // Menambahkan composite index untuk pencarian yang lebih cepat
-            $this->db->query('CREATE INDEX bot_id_key_index ON settings(bot_id, `key`)');
+            // Menambahkan composite unique index untuk memastikan key unik per bot
+            $this->db->query('ALTER TABLE settings ADD CONSTRAINT bot_id_key_unique UNIQUE (bot_id, `key`)');
         }
     }
 


### PR DESCRIPTION
This commit adds a route for `bot_management/reset_cron_key/(:num)` to fix a 404 error.

fix: Correct unique constraint on settings table

The `settings` table had an incorrect `UNIQUE` constraint on the `key` column, which caused errors when trying to save settings for multiple bots.

This commit modifies the database migrations to:
1. Remove the `UNIQUE` constraint from the `key` column.
2. Add a composite `UNIQUE` constraint on `(bot_id, key)`.

This ensures that settings keys are unique per bot, which aligns with the application's logic.