### PR TITLE
feat: Tambahkan fungsionalitas forge database ke halaman pengaturan

### DIFF
--- a/application/controllers/Settings.php
+++ b/application/controllers/Settings.php
@@ -99,4 +99,154 @@ class Settings extends MY_Controller {
         }
         redirect('settings');
     }
+
+    public function forge_database()
+    {
+        if (ENVIRONMENT === 'production') {
+            $this->session->set_flashdata('error_message', 'Operasi reset database tidak diizinkan di lingkungan produksi.');
+            redirect('settings');
+            return;
+        }
+
+        try {
+            $this->load->dbforge();
+
+            // Disable foreign key checks
+            if ($this->db->dbdriver === 'sqlite3') {
+                $this->db->query('PRAGMA foreign_keys = OFF;');
+            } else {
+                $this->db->query('SET FOREIGN_KEY_CHECKS = 0');
+            }
+
+            // Drop all tables except migrations
+            $tables = $this->db->list_tables();
+            foreach ($tables as $table) {
+                if ($table !== 'migrations') {
+                    $this->dbforge->drop_table($table, TRUE, TRUE);
+                }
+            }
+
+            // Recreate tables
+            $this->_create_bots_table();
+            $this->_create_bot_logs_table();
+            $this->_create_settings_table();
+            $this->_create_users_table();
+            $this->_create_keyword_replies_table();
+            $this->_create_broadcasts_table();
+
+            // Re-enable foreign key checks
+            if ($this->db->dbdriver === 'sqlite3') {
+                $this->db->query('PRAGMA foreign_keys = ON;');
+            } else {
+                $this->db->query('SET FOREIGN_KEY_CHECKS = 1');
+            }
+
+            // Update migration version to the latest to prevent re-running
+            if ($this->db->table_exists('migrations')) {
+                $this->db->update('migrations', ['version' => '20250808193600']);
+            }
+
+            $this->session->set_flashdata('success_message', 'Database berhasil di-forge. Semua tabel telah dibuat ulang ke keadaan awal.');
+        } catch (Exception $e) {
+            $this->session->set_flashdata('error_message', 'Terjadi kesalahan saat forge database: ' . $e->getMessage());
+        }
+
+        redirect('settings');
+    }
+
+    private function _create_bots_table()
+    {
+        $this->dbforge->add_field([
+            'id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE, 'auto_increment' => TRUE],
+            'name' => ['type' => 'VARCHAR', 'constraint' => '255'],
+            'token' => ['type' => 'TEXT'],
+            'webhook_token' => ['type' => 'VARCHAR', 'constraint' => 100, 'null' => TRUE, 'unique' => TRUE],
+            'created_at' => ['type' => 'TIMESTAMP', 'default' => 'CURRENT_TIMESTAMP'],
+        ]);
+        $this->dbforge->add_key('id', TRUE);
+        $this->dbforge->create_table('bots');
+    }
+
+    private function _create_bot_logs_table()
+    {
+        $this->dbforge->add_field([
+            'id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE, 'auto_increment' => TRUE],
+            'bot_id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE],
+            'update_id' => ['type' => 'VARCHAR', 'constraint' => '255', 'null' => TRUE],
+            'message_data' => ['type' => 'TEXT', 'null' => TRUE],
+            'chat_id' => ['type' => 'VARCHAR', 'constraint' => '255', 'null' => TRUE],
+            'chat_type' => ['type' => 'VARCHAR', 'constraint' => '255', 'null' => TRUE],
+            'created_at' => ['type' => 'TIMESTAMP', 'default' => 'CURRENT_TIMESTAMP'],
+        ]);
+        $this->dbforge->add_key('id', TRUE);
+        $this->dbforge->create_table('bot_logs');
+    }
+
+    private function _create_settings_table()
+    {
+        $this->dbforge->add_field([
+            'id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE, 'auto_increment' => TRUE],
+            'bot_id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE, 'null' => TRUE],
+            'key' => ['type' => 'VARCHAR', 'constraint' => '255'],
+            'value' => ['type' => 'TEXT', 'null' => TRUE],
+        ]);
+        $this->dbforge->add_key('id', TRUE);
+        $this->dbforge->create_table('settings');
+        $this->db->query('CREATE UNIQUE INDEX key_bot_id_unique ON settings (key, bot_id)');
+    }
+
+    private function _create_users_table()
+    {
+        $this->dbforge->add_field([
+            'id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE, 'auto_increment' => TRUE],
+            'bot_id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE],
+            'telegram_id' => ['type' => 'BIGINT'],
+            'first_name' => ['type' => 'VARCHAR', 'constraint' => '255'],
+            'last_name' => ['type' => 'VARCHAR', 'constraint' => '255', 'null' => TRUE],
+            'username' => ['type' => 'VARCHAR', 'constraint' => '255', 'null' => TRUE],
+            'language_code' => ['type' => 'VARCHAR', 'constraint' => '10', 'null' => TRUE],
+            'is_bot' => ['type' => 'BOOLEAN', 'default' => FALSE],
+            'status' => ['type' => 'VARCHAR', 'constraint' => '50', 'default' => 'active'],
+            'segment' => ['type' => 'VARCHAR', 'constraint' => '255', 'null' => TRUE],
+            'created_at' => ['type' => 'TIMESTAMP', 'default' => 'CURRENT_TIMESTAMP'],
+            'updated_at' => ['type' => 'TIMESTAMP', 'default' => 'CURRENT_TIMESTAMP'],
+        ]);
+        $this->dbforge->add_key('id', TRUE);
+        $this->dbforge->create_table('users');
+        $this->db->query('CREATE UNIQUE INDEX telegram_bot_id_unique ON users (telegram_id, bot_id)');
+    }
+
+    private function _create_keyword_replies_table()
+    {
+        $this->dbforge->add_field([
+            'id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE, 'auto_increment' => TRUE],
+            'keyword' => ['type' => 'VARCHAR', 'constraint' => '255'],
+            'reply_message' => ['type' => 'TEXT'],
+            'is_global' => ['type' => 'BOOLEAN', 'default' => FALSE],
+            'bot_id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE, 'null' => TRUE],
+            'created_at' => ['type' => 'TIMESTAMP', 'default' => 'CURRENT_TIMESTAMP'],
+        ]);
+        $this->dbforge->add_key('id', TRUE);
+        $this->dbforge->create_table('keyword_replies');
+    }
+
+    private function _create_broadcasts_table()
+    {
+        $this->dbforge->add_field([
+            'id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE, 'auto_increment' => TRUE],
+            'bot_id' => ['type' => 'INT', 'constraint' => 11, 'unsigned' => TRUE],
+            'message' => ['type' => 'TEXT'],
+            'target_segment' => ['type' => 'VARCHAR', 'constraint' => '255', 'null' => TRUE],
+            'status' => ['type' => 'VARCHAR', 'constraint' => '50', 'default' => 'pending'],
+            'total_recipients' => ['type' => 'INT', 'null' => TRUE],
+            'sent_count' => ['type' => 'INT', 'default' => 0],
+            'failed_count' => ['type' => 'INT', 'default' => 0],
+            'error_message' => ['type' => 'TEXT', 'null' => TRUE],
+            'created_at' => ['type' => 'TIMESTAMP', 'default' => 'CURRENT_TIMESTAMP'],
+            'scheduled_at' => ['type' => 'DATETIME', 'null' => TRUE],
+            'completed_at' => ['type' => 'DATETIME', 'null' => TRUE],
+        ]);
+        $this->dbforge->add_key('id', TRUE);
+        $this->dbforge->create_table('broadcasts');
+    }
 }

--- a/application/views/settings_view.php
+++ b/application/views/settings_view.php
@@ -1,19 +1,20 @@
-<?php $this->load->view('templates/header', ['title' => 'Pengaturan Bot']); ?>
+<?php $this->load->view('templates/header', ['title' => 'Pengaturan']); ?>
+
+<h1 class="mb-4">Pengaturan</h1>
+
+<?php if ($this->session->flashdata('success_message')): ?>
+    <div class="alert alert-success"><?= $this->session->flashdata('success_message'); ?></div>
+<?php endif; ?>
+<?php if ($this->session->flashdata('error_message')): ?>
+    <div class="alert alert-danger"><?= $this->session->flashdata('error_message'); ?></div>
+<?php endif; ?>
 
 <?php if (!$selected_bot): ?>
     <div class="alert alert-warning">
-        Silakan <a href="<?= site_url('bot_management') ?>">tambahkan bot</a> atau pilih bot dari menu di atas untuk mengelola pengaturan.
+        Silakan <a href="<?= site_url('bot_management') ?>">tambahkan bot</a> atau pilih bot dari menu di atas untuk mengelola pengaturan spesifik bot.
     </div>
 <?php else: ?>
-    <h1 class="mb-4">Pengaturan untuk Bot: <?= html_escape($selected_bot['name']); ?></h1>
-
-    <?php if ($this->session->flashdata('success_message')): ?>
-        <div class="alert alert-success"><?= $this->session->flashdata('success_message'); ?></div>
-    <?php endif; ?>
-    <?php if ($this->session->flashdata('error_message')): ?>
-        <div class="alert alert-danger"><?= $this->session->flashdata('error_message'); ?></div>
-    <?php endif; ?>
-
+    <h2 class="h3 mb-3">Pengaturan untuk Bot: <?= html_escape($selected_bot['name']); ?></h2>
     <div class="row">
         <div class="col-lg-6">
             <div class="card mb-4">
@@ -51,6 +52,27 @@
     <?php endif; ?>
 
 <?php endif; ?>
+
+<hr class="my-4">
+
+<h2 class="h3 mb-3">Pengaturan Database</h2>
+<div class="row">
+    <div class="col-lg-6">
+        <div class="card mb-4 border-danger">
+            <div class="card-header bg-danger text-white">
+                <i class="bi bi-exclamation-triangle-fill"></i> Zona Berbahaya
+            </div>
+            <div class="card-body">
+                <p>Menekan tombol ini akan <strong>menghapus semua data</strong> dan mengatur ulang database ke status awal. Semua bot, pengguna, log, dan riwayat siaran akan hilang secara permanen.</p>
+                <p class="text-danger">Tindakan ini tidak dapat diurungkan. Lanjutkan dengan hati-hati.</p>
+                <a href="<?= site_url('settings/forge_database'); ?>" class="btn btn-danger" onclick="return confirm('PERINGATAN: Anda akan menghapus SEMUA data di database. Apakah Anda benar-benar yakin ingin melanjutkan?');">
+                    <i class="bi bi-trash-fill"></i> Forge Database
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+
 
 <script>
     // Toggle Bot Token Visibility


### PR DESCRIPTION
Menambahkan bagian baru ke halaman Pengaturan untuk manajemen database. Bagian ini menyertakan tombol "Forge Database" yang memungkinkan Anda untuk mengatur ulang seluruh database aplikasi ke keadaan awal.

Perubahan utama:
- Memodifikasi `Settings.php` untuk menambahkan metode `forge_database()`. Metode ini menghapus semua tabel aplikasi dan membuatnya kembali menggunakan `dbforge`. Ini termasuk pemeriksaan keamanan untuk mencegah eksekusi di lingkungan produksi.
- Memperbarui `settings_view.php` untuk menyertakan "Zona Berbahaya" dengan tombol "Forge Database" dan peringatan yang jelas tentang sifat destruktif dari tindakan tersebut.
- Skema database didefinisikan dalam metode privat di controller, memenuhi persyaratan untuk tidak menggunakan sistem migrasi untuk proses reset.
- Versi tabel `migrations` diperbarui setelah forging untuk mencegah konflik dengan sistem migrasi.