### PR TITLE
fix: Cegah penghapusan tabel sistem sqlite_sequence

### DIFF
--- a/application/controllers/Settings.php
+++ b/application/controllers/Settings.php
@@ -118,10 +118,10 @@ class Settings extends MY_Controller {
                 $this->db->query('SET FOREIGN_KEY_CHECKS = 0');
             }
 
-            // Drop all tables except migrations
+            // Drop all tables except migrations and sqlite system tables
             $tables = $this->db->list_tables();
             foreach ($tables as $table) {
-                if ($table !== 'migrations') {
+                if ($table !== 'migrations' && $table !== 'sqlite_sequence') {
                     $this->dbforge->drop_table($table, TRUE, TRUE);
                 }
             }


### PR DESCRIPTION
Commit ini memperbaiki bug pada fungsionalitas `forge_database` di mana ia akan mencoba menghapus tabel `sqlite_sequence` saat berjalan pada database SQLite. Tindakan ini tidak diizinkan oleh SQLite dan menyebabkan peringatan PHP.

Perbaikan ini mengubah loop penghapusan tabel untuk secara eksplisit mengabaikan tabel `sqlite_sequence`, selain tabel `migrations`.