### PR TITLE
fix: Perbaiki pembuatan URL webhook di BotManagement

### DIFF
--- a/application/controllers/BotManagement.php
+++ b/application/controllers/BotManagement.php
@@ -125,7 +125,13 @@ class BotManagement extends MY_Controller {
         }
 
         try {
-            $webhook_url = site_url('bot_webhook/handle/' . $bot_id);
+            $bot = $this->BotModel->getBotById($bot_id);
+            if (empty($bot) || empty($bot['webhook_token'])) {
+                $this->output->set_status_header(400)->set_content_type('application/json')->set_output(json_encode(['ok' => false, 'error' => 'Bot data is incomplete or missing webhook token.']));
+                return;
+            }
+
+            $webhook_url = site_url('bot/webhook/' . $bot['webhook_token']);
             $result = $api->setWebhook($webhook_url);
             $this->output->set_content_type('application/json')->set_output(json_encode($result));
         } catch (Exception $e) {


### PR DESCRIPTION
Commit ini memperbaiki bug kritis di endpoint API `set_webhook` yang ada di controller `BotManagement`.

Metode ini sebelumnya salah membuat URL webhook menggunakan ID internal bot dan menunjuk ke path controller yang salah (`bot_webhook/handle/:id`). Ini menyebabkan pengaturan webhook gagal.

Logika sekarang diperbaiki untuk:
1. Mengambil data bot untuk mendapatkan `webhook_token` uniknya.
2. Membangun URL menggunakan rute publik yang benar (`bot/webhook/:token`).