### PR TITLE
feat: Implement modular handler system for Telegram bots

### DIFF
--- a/application/controllers/BotManagement.php
+++ b/application/controllers/BotManagement.php
@@ -39,12 +39,23 @@ class BotManagement extends MY_Controller {
         if (empty($data['bot'])) {
             show_404();
         }
-        $this->load->view('bot_edit_view', $data); // We need to create this view
+
+        // Scan for available handlers
+        $handler_files = glob(FCPATH . 'bot/*Handler.php');
+        $available_handlers = [];
+        foreach ($handler_files as $file) {
+            // Get class name from filename
+            $available_handlers[] = basename($file, '.php');
+        }
+        $data['available_handlers'] = $available_handlers;
+
+        $this->load->view('bot_edit_view', $data);
     }
 
     public function update($id) {
         $this->form_validation->set_rules('name', 'Nama Bot', 'required|trim');
         $this->form_validation->set_rules('token', 'Token API Telegram', 'required|trim');
+        $this->form_validation->set_rules('handler_type', 'Tipe Handler', 'required|trim');
 
         if ($this->form_validation->run() == FALSE) {
             $this->edit($id);
@@ -52,6 +63,7 @@ class BotManagement extends MY_Controller {
             $bot_data = [
                 'name' => $this->input->post('name'),
                 'token' => $this->input->post('token'),
+                'handler_type' => $this->input->post('handler_type'),
             ];
             $this->db->where('id', $id)->update('bots', $bot_data);
             redirect('bot_management');

--- a/application/controllers/Bot_webhook.php
+++ b/application/controllers/Bot_webhook.php
@@ -25,12 +25,24 @@ class Bot_webhook extends CI_Controller {
             $this->load->model('UserModel');
             $this->load->model('KeywordModel');
 
+            // --- Dynamic Handler Loading ---
+            $handler_class = $bot['handler_type'] ?? 'DefaultBotHandler';
+            $handler_file = FCPATH . 'bot/' . $handler_class . '.php';
+
+            if (!file_exists($handler_file)) {
+                throw new Exception("Handler file not found: {$handler_file}");
+            }
+            require_once $handler_file;
+            if (!class_exists($handler_class)) {
+                throw new Exception("Handler class not found: {$handler_class}");
+            }
+            // --- End Dynamic Handler Loading ---
+
             require_once FCPATH . 'bot/ApiClient.php';
-            require_once FCPATH . 'bot/BotHandler.php';
 
             // Inisialisasi komponen bot dengan bot_id
             $apiClient = new ApiClient($bot_api_token, $this->Log_model, $bot_id);
-            $botHandler = new BotHandler(
+            $botHandler = new $handler_class(
                 $apiClient,
                 $this->Log_model,
                 $this->UserModel,

--- a/application/migrations/20250810101900_add_handler_type_to_bots_table.php
+++ b/application/migrations/20250810101900_add_handler_type_to_bots_table.php
@@ -1,0 +1,24 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Add_handler_type_to_bots_table extends CI_Migration {
+
+    public function up()
+    {
+        $fields = array(
+            'handler_type' => array(
+                'type' => 'VARCHAR',
+                'constraint' => '255',
+                'null' => FALSE,
+                'default' => 'DefaultBotHandler'
+            )
+        );
+        $this->dbforge->add_column('bots', $fields);
+    }
+
+    public function down()
+    {
+        $this->dbforge->drop_column('bots', 'handler_type');
+    }
+}

--- a/application/views/bot_edit_view.php
+++ b/application/views/bot_edit_view.php
@@ -15,6 +15,17 @@
                     <input type="text" name="token" class="form-control" value="<?= set_value('token', $bot['token']) ?>" required>
                     <?= form_error('token', '<div class="text-danger small">', '</div>') ?>
                 </div>
+                <div class="mb-3">
+                    <label for="handler_type" class="form-label">Tipe Handler</label>
+                    <select name="handler_type" class="form-select" required>
+                        <?php foreach ($available_handlers as $handler): ?>
+                            <option value="<?= $handler ?>" <?= set_select('handler_type', $handler, ($bot['handler_type'] == $handler)) ?>>
+                                <?= $handler ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                    <?= form_error('handler_type', '<div class="text-danger small">', '</div>') ?>
+                </div>
                 <hr>
                 <button type="submit" class="btn btn-primary">Simpan Perubahan</button>
                 <a href="<?= site_url('bot_management') ?>" class="btn btn-secondary">Batal</a>

--- a/bot/DefaultBotHandler.php
+++ b/bot/DefaultBotHandler.php
@@ -1,6 +1,8 @@
 <?php
 
-class BotHandler
+require_once __DIR__ . '/HandlerInterface.php';
+
+class DefaultBotHandler implements HandlerInterface
 {
     protected ApiClient $api;
     protected Log_model $logger;

--- a/bot/EchoBotHandler.php
+++ b/bot/EchoBotHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+require_once __DIR__ . '/HandlerInterface.php';
+
+class EchoBotHandler implements HandlerInterface
+{
+    protected ApiClient $api;
+    protected Log_model $logger;
+    protected int $bot_id;
+
+    // We keep the constructor signature compatible for simplicity,
+    // even though this handler doesn't use all the models.
+    public function __construct(ApiClient $api, Log_model $logger, UserModel $userModel, KeywordModel $keywordModel, Settings_model $settingsModel, int $bot_id)
+    {
+        $this->api = $api;
+        $this->logger = $logger;
+        $this->bot_id = $bot_id;
+    }
+
+    public function handle(string $rawUpdate): void
+    {
+        $update = json_decode($rawUpdate, true);
+
+        if (!isset($update['message'])) {
+            return; // Not a message, ignore
+        }
+
+        $message = $update['message'];
+        $chatId = $message['chat']['id'];
+        $text = $message['text'] ?? '';
+
+        // Log the incoming message
+        $chatName = $message['chat']['first_name'] ?? 'Unknown';
+        $this->logger->add_log('incoming', $rawUpdate, $chatId, $chatName, $this->bot_id);
+
+        if (!empty($text)) {
+            // Echo the exact same text back to the user
+            $this->api->sendMessage($chatId, $text);
+        } else {
+            // Handle cases where the message is not text (e.g., a photo or sticker)
+            $this->api->sendMessage($chatId, "Saya hanya bisa menggemakan pesan teks.");
+        }
+    }
+}

--- a/bot/HandlerInterface.php
+++ b/bot/HandlerInterface.php
@@ -1,0 +1,6 @@
+<?php
+
+interface HandlerInterface
+{
+    public function handle(string $rawUpdate): void;
+}


### PR DESCRIPTION
This commit refactors the Telegram bot webhook to support modular, swappable handlers. This allows different bots to have distinct behaviors by assigning them different handler classes.

Key changes:
- Introduced a `HandlerInterface` to ensure a consistent contract for all bot logic handlers.
- Refactored the original `BotHandler` into `DefaultBotHandler` and added a new `EchoBotHandler` as an example.
- Added a `handler_type` column to the `bots` table via a new database migration to store the assigned handler for each bot.
- Updated the `Bot_webhook` controller to dynamically load and instantiate the correct handler class based on the bot's `handler_type`.
- Modified the Bot Management admin interface to allow you to select the desired handler from a dropdown menu, which is populated by scanning the `bot/` directory for available handlers.